### PR TITLE
release: v0.5.0

### DIFF
--- a/src/AppConfiguration.cs
+++ b/src/AppConfiguration.cs
@@ -58,6 +58,9 @@ public class AppConfiguration : IAppConfiguration
     public string? TargetMediaPlayer => _configuration["HomeAssistant:TargetMediaPlayer"];
 
     /// <inheritdoc/>
+    public string? AudioDeviceId => _configuration["HomeAssistant:AudioDeviceId"];
+
+    /// <inheritdoc/>
     public bool StrictTLS => _configuration.GetValue<bool>("HomeAssistant:StrictTLS", true);
 
     /// <inheritdoc/>

--- a/src/IAppConfiguration.cs
+++ b/src/IAppConfiguration.cs
@@ -42,7 +42,9 @@ public interface IAppConfiguration
     /// <summary>
     /// Gets the Windows audio device ID to monitor.
     /// Empty string or null means use the Windows default output device.
-    /// The value is the MMDevice.ID GUID string from the Core Audio API.
+    /// The value is the NAudio <c>MMDevice.ID</c> Core Audio endpoint ID string
+    /// (for example <c>"{0.0.0.00000000}.{&lt;guid&gt;}"</c>) and should be treated
+    /// as an opaque identifier, not a plain GUID.
     /// </summary>
     string? AudioDeviceId { get; }
 

--- a/src/IAppConfiguration.cs
+++ b/src/IAppConfiguration.cs
@@ -40,6 +40,13 @@ public interface IAppConfiguration
     string? TargetMediaPlayer { get; }
 
     /// <summary>
+    /// Gets the Windows audio device ID to monitor.
+    /// Empty string or null means use the Windows default output device.
+    /// The value is the MMDevice.ID GUID string from the Core Audio API.
+    /// </summary>
+    string? AudioDeviceId { get; }
+
+    /// <summary>
     /// Gets whether strict TLS validation is enabled.
     /// Defaults to true for security.
     /// </summary>

--- a/src/SettingsForm.cs
+++ b/src/SettingsForm.cs
@@ -1,3 +1,4 @@
+using NAudio.CoreAudioApi;
 using System.Windows.Forms;
 
 namespace HomeAssistantWindowsVolumeSync;
@@ -8,7 +9,7 @@ namespace HomeAssistantWindowsVolumeSync;
 public class SettingsForm : Form
 {
     private readonly IAppConfiguration _configuration;
-    private readonly Action<string, string, string> _saveSettings;
+    private readonly Action<string, string, string, string> _saveSettings;
 
     private static readonly System.Drawing.Font _labelFont = new System.Drawing.Font("Segoe UI", 9F);
     private static readonly System.Drawing.Font _textBoxFont = new System.Drawing.Font("Segoe UI", 9F);
@@ -18,6 +19,7 @@ public class SettingsForm : Form
     private TextBox _webhookUrlTextBox = null!;
     private TextBox _webhookIdTextBox = null!;
     private TextBox _targetMediaPlayerTextBox = null!;
+    private ComboBox _audioDeviceComboBox = null!;
     private CheckBox _runOnStartupCheckBox = null!;
     private Button _saveButton = null!;
     private Button _cancelButton = null!;
@@ -25,13 +27,18 @@ public class SettingsForm : Form
     private Label _webhookUrlLabel = null!;
     private Label _webhookIdLabel = null!;
     private Label _targetMediaPlayerLabel = null!;
+    private Label _audioDeviceLabel = null!;
     private ToolTip _toolTip = null!;
 
-    public SettingsForm(IAppConfiguration configuration, Action<string, string, string> saveSettings)
+    // Stores (deviceId, displayName) pairs for the combo box items
+    private readonly List<(string Id, string Name)> _audioDevices = new();
+
+    public SettingsForm(IAppConfiguration configuration, Action<string, string, string, string> saveSettings)
     {
         _configuration = configuration;
         _saveSettings = saveSettings;
         InitializeComponents();
+        PopulateAudioDevices();
         LoadSettings();
     }
 
@@ -40,7 +47,7 @@ public class SettingsForm : Form
         // Form settings
         Text = "Home Assistant Volume Sync - Settings";
         Width = 600;
-        Height = 330;
+        Height = 390;
         FormBorderStyle = FormBorderStyle.FixedDialog;
         MaximizeBox = false;
         MinimizeBox = false;
@@ -123,12 +130,38 @@ public class SettingsForm : Form
         };
         Controls.Add(_targetMediaPlayerTextBox);
 
+        // Audio Device Label
+        _audioDeviceLabel = new Label
+        {
+            Text = "Audio Device to Monitor:",
+            Left = 20,
+            Top = 200,
+            Width = 200,
+            Font = _labelFont
+        };
+        Controls.Add(_audioDeviceLabel);
+
+        // Audio Device ComboBox
+        _audioDeviceComboBox = new ComboBox
+        {
+            Left = 20,
+            Top = 225,
+            Width = 540,
+            Font = _textBoxFont,
+            DropDownStyle = ComboBoxStyle.DropDownList
+        };
+        _toolTip.SetToolTip(_audioDeviceComboBox,
+            "Select which Windows audio output device to monitor.\n" +
+            "\"Default\" always follows the current Windows default output device.\n" +
+            "A specific device is used even if you switch your Windows default.");
+        Controls.Add(_audioDeviceComboBox);
+
         // Run on Startup CheckBox
         _runOnStartupCheckBox = new CheckBox
         {
             Text = "Run when Windows starts",
             Left = 20,
-            Top = 200,
+            Top = 265,
             Width = 540,
             Font = _textBoxFont
         };
@@ -188,12 +221,52 @@ public class SettingsForm : Form
         CancelButton = _cancelButton;
     }
 
+    /// <summary>
+    /// Enumerates active Windows audio output devices and populates the combo box.
+    /// Called once when the form opens so newly connected devices are always visible.
+    /// </summary>
+    private void PopulateAudioDevices()
+    {
+        _audioDevices.Clear();
+        _audioDeviceComboBox.Items.Clear();
+
+        // First item: always "Default" — uses Windows default output (empty device ID)
+        _audioDevices.Add(("", "Default (Windows default output)"));
+        _audioDeviceComboBox.Items.Add("Default (Windows default output)");
+
+        try
+        {
+            using var enumerator = new MMDeviceEnumerator();
+            var devices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+            foreach (var device in devices)
+            {
+                _audioDevices.Add((device.ID, device.FriendlyName));
+                _audioDeviceComboBox.Items.Add(device.FriendlyName);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal — user can still see "Default" and save other settings
+            _toolTip.SetToolTip(_audioDeviceComboBox,
+                $"Could not enumerate audio devices: {ex.Message}\n" +
+                "Only the default device option is available.");
+        }
+
+        _audioDeviceComboBox.SelectedIndex = 0;
+    }
+
     private void LoadSettings()
     {
         _webhookUrlTextBox.Text = _configuration.WebhookUrl ?? "";
         _webhookIdTextBox.Text = _configuration.WebhookId ?? "";
         _targetMediaPlayerTextBox.Text = _configuration.TargetMediaPlayer ?? "";
         _runOnStartupCheckBox.Checked = WindowsStartupManager.IsStartupEnabled();
+
+        // Select the configured device in the combo box
+        var configuredDeviceId = _configuration.AudioDeviceId ?? "";
+        var deviceIndex = _audioDevices.FindIndex(d =>
+            string.Equals(d.Id, configuredDeviceId, StringComparison.OrdinalIgnoreCase));
+        _audioDeviceComboBox.SelectedIndex = deviceIndex >= 0 ? deviceIndex : 0;
     }
 
     private void OnSaveClick(object? sender, EventArgs e)
@@ -201,6 +274,9 @@ public class SettingsForm : Form
         var webhookUrl = _webhookUrlTextBox.Text.Trim();
         var webhookId = _webhookIdTextBox.Text.Trim();
         var targetMediaPlayer = _targetMediaPlayerTextBox.Text.Trim();
+        var audioDeviceId = _audioDeviceComboBox.SelectedIndex >= 0
+            ? _audioDevices[_audioDeviceComboBox.SelectedIndex].Id
+            : "";
 
         if (string.IsNullOrWhiteSpace(webhookUrl))
         {
@@ -237,7 +313,7 @@ public class SettingsForm : Form
 
         try
         {
-            _saveSettings(webhookUrl, webhookId, targetMediaPlayer);
+            _saveSettings(webhookUrl, webhookId, targetMediaPlayer, audioDeviceId);
 
             // Handle Windows startup setting
             try

--- a/src/SettingsManager.cs
+++ b/src/SettingsManager.cs
@@ -30,7 +30,7 @@ public class SettingsManager
     /// <summary>
     /// Saves the Home Assistant settings to appsettings.json and reloads configuration
     /// </summary>
-    public void SaveSettings(string webhookUrl, string webhookId, string targetMediaPlayer)
+    public void SaveSettings(string webhookUrl, string webhookId, string targetMediaPlayer, string audioDeviceId = "")
     {
         _logger?.LogInformation("Saving settings to {FilePath}", _settingsFilePath);
         _logger?.LogDebug("New settings - WebhookUrl: {Url}, WebhookId: {Id}, TargetMediaPlayer: {Player}",
@@ -69,6 +69,7 @@ public class SettingsManager
                 homeAssistantSettings["WebhookUrl"] = webhookUrl;
                 homeAssistantSettings["WebhookId"] = webhookId;
                 homeAssistantSettings["TargetMediaPlayer"] = targetMediaPlayer;
+                homeAssistantSettings["AudioDeviceId"] = audioDeviceId;
 
                 settings[property.Name] = homeAssistantSettings;
             }
@@ -88,6 +89,7 @@ public class SettingsManager
                 ["WebhookPath"] = "/api/webhook/",
                 ["WebhookId"] = webhookId,
                 ["TargetMediaPlayer"] = targetMediaPlayer,
+                ["AudioDeviceId"] = audioDeviceId,
                 ["StrictTLS"] = true  // Default to secure
             };
         }
@@ -120,7 +122,8 @@ public class SettingsManager
             {
                 if (string.Equals(_appConfiguration.WebhookUrl, webhookUrl, StringComparison.Ordinal) &&
                     string.Equals(_appConfiguration.WebhookId, webhookId, StringComparison.Ordinal) &&
-                    string.Equals(_appConfiguration.TargetMediaPlayer, targetMediaPlayer, StringComparison.Ordinal))
+                    string.Equals(_appConfiguration.TargetMediaPlayer, targetMediaPlayer, StringComparison.Ordinal) &&
+                    string.Equals(_appConfiguration.AudioDeviceId ?? "", audioDeviceId, StringComparison.Ordinal))
                 {
                     configUpdated = true;
                     break;

--- a/src/SettingsManager.cs
+++ b/src/SettingsManager.cs
@@ -69,7 +69,12 @@ public class SettingsManager
                 homeAssistantSettings["WebhookUrl"] = webhookUrl;
                 homeAssistantSettings["WebhookId"] = webhookId;
                 homeAssistantSettings["TargetMediaPlayer"] = targetMediaPlayer;
-                homeAssistantSettings["AudioDeviceId"] = audioDeviceId;
+                // Persist AudioDeviceId only when a specific device is selected.
+                // Omit (or remove) the key when empty so null and "" both mean "use Windows default".
+                if (string.IsNullOrEmpty(audioDeviceId))
+                    homeAssistantSettings.Remove("AudioDeviceId");
+                else
+                    homeAssistantSettings["AudioDeviceId"] = audioDeviceId;
 
                 settings[property.Name] = homeAssistantSettings;
             }
@@ -83,15 +88,18 @@ public class SettingsManager
         // If HomeAssistant section doesn't exist, create it
         if (!settings.ContainsKey("HomeAssistant"))
         {
-            settings["HomeAssistant"] = new Dictionary<string, object?>
+            var newSection = new Dictionary<string, object?>
             {
                 ["WebhookUrl"] = webhookUrl,
                 ["WebhookPath"] = "/api/webhook/",
                 ["WebhookId"] = webhookId,
                 ["TargetMediaPlayer"] = targetMediaPlayer,
-                ["AudioDeviceId"] = audioDeviceId,
                 ["StrictTLS"] = true  // Default to secure
             };
+            // Only persist AudioDeviceId when a specific device is selected
+            if (!string.IsNullOrEmpty(audioDeviceId))
+                newSection["AudioDeviceId"] = audioDeviceId;
+            settings["HomeAssistant"] = newSection;
         }
 
         // Write the updated settings back to the file

--- a/src/SystemTrayService.cs
+++ b/src/SystemTrayService.cs
@@ -409,7 +409,7 @@ public class SystemTrayService : BackgroundService
             var settingsManager = new SettingsManager(_configuration, settingsManagerLogger);
             _settingsForm = new SettingsForm(
                 _configuration,
-                (url, id, player) => settingsManager.SaveSettings(url, id, player));
+                (url, id, player, deviceId) => settingsManager.SaveSettings(url, id, player, deviceId));
 
             // Handle form closing to clear the reference
             _settingsForm.FormClosed += (s, args) =>

--- a/src/VolumeWatcherService.cs
+++ b/src/VolumeWatcherService.cs
@@ -14,13 +14,64 @@ public class VolumeWatcherService : BackgroundService
     private readonly IHomeAssistantClient _homeAssistantClient;
     private readonly IAppConfiguration _configuration;
     private MMDeviceEnumerator? _deviceEnumerator;
-    private MMDevice? _defaultDevice;
+    private MMDevice? _monitoredDevice;
     private AudioEndpointVolumeNotificationDelegate? _volumeDelegate;
     private volatile bool _isPaused;
     private CancellationTokenSource? _debounceCts;
     private float _lastVolumeScalar;
     private bool _lastMuteState;
     private readonly object _debounceLock = new object();
+
+    /// <summary>
+    /// Resolves which audio device to monitor based on the configured device ID.
+    /// Extracted for testability — callers inject the enumerator functions.
+    /// </summary>
+    /// <typeparam name="TDevice">Device type (e.g. <see cref="MMDevice"/> in production; any stub in tests).</typeparam>
+    /// <param name="configuredDeviceId">Value of <see cref="IAppConfiguration.AudioDeviceId"/>.</param>
+    /// <param name="getDevice">Resolves a device by ID; throws <see cref="System.Runtime.InteropServices.COMException"/> if not found.</param>
+    /// <param name="getDefaultDevice">Resolves the Windows default audio output device.</param>
+    /// <param name="getName">Returns a human-readable name from a device instance (e.g. <c>d =&gt; d.FriendlyName</c>).</param>
+    /// <param name="logWarning">Called when the configured device is not found and fallback occurs.</param>
+    /// <param name="logInfo">Called on successful resolution: first arg is "configured" or "default".</param>
+    /// <returns>The resolved device, or <c>null</c> if no device is available.</returns>
+    internal static TDevice? ResolveMonitoredDevice<TDevice>(
+        string? configuredDeviceId,
+        Func<string, TDevice?> getDevice,
+        Func<TDevice?> getDefaultDevice,
+        Func<TDevice, string?> getName,
+        Action<System.Runtime.InteropServices.COMException, string> logWarning,
+        Action<string, string?> logInfo)
+        where TDevice : class
+    {
+        TDevice? device = null;
+
+        if (!string.IsNullOrEmpty(configuredDeviceId))
+        {
+            try
+            {
+                device = getDevice(configuredDeviceId);
+
+                if (device is not null)
+                {
+                    logInfo("configured", getName(device));
+                    return device;
+                }
+            }
+            catch (System.Runtime.InteropServices.COMException ex)
+            {
+                logWarning(ex, configuredDeviceId);
+            }
+        }
+
+        device = getDefaultDevice();
+
+        if (device is not null)
+        {
+            logInfo("default", getName(device));
+        }
+
+        return device;
+    }
 
     public VolumeWatcherService(
         ILogger<VolumeWatcherService> logger,
@@ -47,15 +98,15 @@ public class VolumeWatcherService : BackgroundService
     /// <returns>Tuple containing (volume percent, is muted), or null if no audio device available.</returns>
     public virtual (int volumePercent, bool isMuted)? GetCurrentVolumeState()
     {
-        if (_defaultDevice?.AudioEndpointVolume == null)
+        if (_monitoredDevice?.AudioEndpointVolume == null)
         {
             return null;
         }
 
         try
         {
-            var volumeScalar = _defaultDevice.AudioEndpointVolume.MasterVolumeLevelScalar;
-            var isMuted = _defaultDevice.AudioEndpointVolume.Mute;
+            var volumeScalar = _monitoredDevice.AudioEndpointVolume.MasterVolumeLevelScalar;
+            var isMuted = _monitoredDevice.AudioEndpointVolume.Mute;
             var volumePercent = (int)Math.Round(volumeScalar * 100);
             return (volumePercent, isMuted);
         }
@@ -78,48 +129,41 @@ public class VolumeWatcherService : BackgroundService
             try
             {
                 var configuredDeviceId = _configuration.AudioDeviceId;
-                if (!string.IsNullOrEmpty(configuredDeviceId))
-                {
-                    try
+                _monitoredDevice = ResolveMonitoredDevice(
+                    configuredDeviceId,
+                    id => (MMDevice?)_deviceEnumerator.GetDevice(id),
+                    () => (MMDevice?)_deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia),
+                    d => d.FriendlyName,
+                    (ex, id) => _logger.LogWarning(ex,
+                        "Configured audio device {DeviceId} not found. Falling back to Windows default output.", id),
+                    (kind, name) =>
                     {
-                        _defaultDevice = _deviceEnumerator.GetDevice(configuredDeviceId);
-                        _logger.LogInformation("Using configured audio device: {DeviceName} ({DeviceId})",
-                            _defaultDevice.FriendlyName, configuredDeviceId);
-                    }
-                    catch (System.Runtime.InteropServices.COMException ex)
-                    {
-                        _logger.LogWarning(ex,
-                            "Configured audio device {DeviceId} not found. Falling back to Windows default output.",
-                            configuredDeviceId);
-                        _defaultDevice = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-                    }
-                }
-                else
-                {
-                    _defaultDevice = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-                    _logger.LogInformation("Using Windows default audio output device: {DeviceName}",
-                        _defaultDevice.FriendlyName);
-                }
+                        if (kind == "configured")
+                            _logger.LogInformation("Using configured audio device: {DeviceName} ({DeviceId})",
+                                name, configuredDeviceId);
+                        else
+                            _logger.LogInformation("Using Windows default audio output device: {DeviceName}", name);
+                    });
             }
             catch (System.Runtime.InteropServices.COMException ex) when (ex.HResult == unchecked((int)0x80070490))
             {
                 // Element not found - no audio device available
                 _logger.LogWarning("No default audio endpoint found. Service will continue but volume monitoring is disabled.");
-                _defaultDevice = null;
+                _monitoredDevice = null;
             }
 
-            if (_defaultDevice?.AudioEndpointVolume != null)
+            if (_monitoredDevice?.AudioEndpointVolume != null)
             {
                 // Create a delegate that handles volume change events
                 _volumeDelegate = new AudioEndpointVolumeNotificationDelegate(OnVolumeNotification);
-                _defaultDevice.AudioEndpointVolume.OnVolumeNotification += _volumeDelegate;
+                _monitoredDevice.AudioEndpointVolume.OnVolumeNotification += _volumeDelegate;
 
                 _logger.LogInformation("Volume watcher initialized successfully. Listening for volume changes...");
 
                 // Send initial volume state
                 await SendVolumeUpdateAsync(
-                    _defaultDevice.AudioEndpointVolume.MasterVolumeLevelScalar,
-                    _defaultDevice.AudioEndpointVolume.Mute);
+                    _monitoredDevice.AudioEndpointVolume.MasterVolumeLevelScalar,
+                    _monitoredDevice.AudioEndpointVolume.Mute);
             }
             else
             {
@@ -231,9 +275,9 @@ public class VolumeWatcherService : BackgroundService
 
     public override void Dispose()
     {
-        if (_defaultDevice?.AudioEndpointVolume != null && _volumeDelegate != null)
+        if (_monitoredDevice?.AudioEndpointVolume != null && _volumeDelegate != null)
         {
-            _defaultDevice.AudioEndpointVolume.OnVolumeNotification -= _volumeDelegate;
+            _monitoredDevice.AudioEndpointVolume.OnVolumeNotification -= _volumeDelegate;
         }
 
         try
@@ -246,7 +290,7 @@ public class VolumeWatcherService : BackgroundService
         }
 
         _debounceCts?.Dispose();
-        _defaultDevice?.Dispose();
+        _monitoredDevice?.Dispose();
         _deviceEnumerator?.Dispose();
 
         base.Dispose();

--- a/src/VolumeWatcherService.cs
+++ b/src/VolumeWatcherService.cs
@@ -72,12 +72,34 @@ public class VolumeWatcherService : BackgroundService
 
         try
         {
-            // Initialize the device enumerator and get the default audio endpoint
+            // Initialize the device enumerator and get the configured audio endpoint
             _deviceEnumerator = new MMDeviceEnumerator();
 
             try
             {
-                _defaultDevice = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                var configuredDeviceId = _configuration.AudioDeviceId;
+                if (!string.IsNullOrEmpty(configuredDeviceId))
+                {
+                    try
+                    {
+                        _defaultDevice = _deviceEnumerator.GetDevice(configuredDeviceId);
+                        _logger.LogInformation("Using configured audio device: {DeviceName} ({DeviceId})",
+                            _defaultDevice.FriendlyName, configuredDeviceId);
+                    }
+                    catch (System.Runtime.InteropServices.COMException ex)
+                    {
+                        _logger.LogWarning(ex,
+                            "Configured audio device {DeviceId} not found. Falling back to Windows default output.",
+                            configuredDeviceId);
+                        _defaultDevice = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                    }
+                }
+                else
+                {
+                    _defaultDevice = _deviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                    _logger.LogInformation("Using Windows default audio output device: {DeviceName}",
+                        _defaultDevice.FriendlyName);
+                }
             }
             catch (System.Runtime.InteropServices.COMException ex) when (ex.HResult == unchecked((int)0x80070490))
             {

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -34,6 +34,7 @@
     "WebhookPath": "/api/webhook/",
     "WebhookId": "homeassistant_windows_volume_sync",
     "TargetMediaPlayer": "media_player.your_media_player",
+    "AudioDeviceId": "",
     "StrictTLS": true,
     "DebounceTimer": 100,
     "HealthCheckTimer": 5000,

--- a/tests/AppConfigurationTests.cs
+++ b/tests/AppConfigurationTests.cs
@@ -477,4 +477,56 @@ public class AppConfigurationTests
         Assert.Equal("media_player.test", appConfig.TargetMediaPlayer);
         Assert.False(appConfig.StrictTLS);
     }
+
+    [Fact]
+    public void AudioDeviceId_ReturnsConfiguredValue()
+    {
+        // Arrange
+        var deviceId = "{0.0.0.00000000}.{12345678-1234-1234-1234-123456789abc}";
+        var configData = new Dictionary<string, string?>
+        {
+            { "HomeAssistant:AudioDeviceId", deviceId }
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+
+        var appConfig = new AppConfiguration(configuration);
+
+        // Act & Assert
+        Assert.Equal(deviceId, appConfig.AudioDeviceId);
+    }
+
+    [Fact]
+    public void AudioDeviceId_ReturnsEmptyString_WhenConfiguredAsEmpty()
+    {
+        // Arrange
+        var configData = new Dictionary<string, string?>
+        {
+            { "HomeAssistant:AudioDeviceId", "" }
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+
+        var appConfig = new AppConfiguration(configuration);
+
+        // Act & Assert
+        Assert.Equal("", appConfig.AudioDeviceId);
+    }
+
+    [Fact]
+    public void AudioDeviceId_ReturnsNull_WhenNotConfigured()
+    {
+        // Arrange
+        var configData = new Dictionary<string, string?>();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+
+        var appConfig = new AppConfiguration(configuration);
+
+        // Act & Assert
+        Assert.Null(appConfig.AudioDeviceId);
+    }
 }

--- a/tests/IAppConfigurationTests.cs
+++ b/tests/IAppConfigurationTests.cs
@@ -247,4 +247,38 @@ public class IAppConfigurationTests
         Assert.Equal("https://test1.local/webhook", appConfig1.WebhookUrl);
         Assert.Equal("https://test2.local/webhook", appConfig2.WebhookUrl);
     }
+
+    [Fact]
+    public void AudioDeviceId_Interface_ReturnsConfiguredValue()
+    {
+        // Arrange
+        var deviceId = "{0.0.0.00000000}.{aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee}";
+        var configData = new Dictionary<string, string?>
+        {
+            { "HomeAssistant:AudioDeviceId", deviceId }
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+
+        IAppConfiguration appConfig = new AppConfiguration(configuration);
+
+        // Act & Assert
+        Assert.Equal(deviceId, appConfig.AudioDeviceId);
+    }
+
+    [Fact]
+    public void AudioDeviceId_Interface_ReturnsNull_WhenNotConfigured()
+    {
+        // Arrange
+        var configData = new Dictionary<string, string?>();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+
+        IAppConfiguration appConfig = new AppConfiguration(configuration);
+
+        // Act & Assert
+        Assert.Null(appConfig.AudioDeviceId);
+    }
 }

--- a/tests/SettingsManagerTests.cs
+++ b/tests/SettingsManagerTests.cs
@@ -349,7 +349,7 @@ public class SettingsManagerTests : IDisposable
   }
 
   [Fact]
-  public void SaveSettings_SavesEmptyAudioDeviceId_WhenNotProvided()
+  public void SaveSettings_OmitsAudioDeviceId_WhenNotProvided()
   {
     // Arrange
     var settingsManager = CreateSettingsManagerWithoutConfig();
@@ -357,11 +357,9 @@ public class SettingsManagerTests : IDisposable
     // Act
     settingsManager.SaveSettings("https://test.local", "test_webhook", "media_player.test");
 
-    // Assert
+    // Assert - AudioDeviceId should be OMITTED when empty (null/empty = use Windows default, no key needed)
     var json = File.ReadAllText(_testSettingsFile);
-    Assert.Contains("AudioDeviceId", json);
-    // Empty string value
-    Assert.Contains("\"AudioDeviceId\": \"\"", json);
+    Assert.DoesNotContain("AudioDeviceId", json);
   }
 
   [Fact]
@@ -389,5 +387,30 @@ public class SettingsManagerTests : IDisposable
     var json = File.ReadAllText(_testSettingsFile);
     Assert.Contains(newDeviceId, json);
     Assert.Contains("https://new.local", json);
+  }
+
+  [Fact]
+  public void SaveSettings_RemovesAudioDeviceId_WhenSwitchedBackToDefault()
+  {
+    // Arrange — file has an existing specific device ID
+    var initialJson = """
+      {
+        "HomeAssistant": {
+          "WebhookUrl": "https://test.local",
+          "WebhookId": "test_webhook",
+          "TargetMediaPlayer": "media_player.test",
+          "AudioDeviceId": "{0.0.0.00000000}.{some-device-id}"
+        }
+      }
+      """;
+    File.WriteAllText(_testSettingsFile, initialJson);
+    var settingsManager = CreateSettingsManagerWithoutConfig();
+
+    // Act — save with empty audioDeviceId (= switch back to "Default")
+    settingsManager.SaveSettings("https://test.local", "test_webhook", "media_player.test", "");
+
+    // Assert — AudioDeviceId key should be removed
+    var json = File.ReadAllText(_testSettingsFile);
+    Assert.DoesNotContain("AudioDeviceId", json);
   }
 }

--- a/tests/SettingsManagerTests.cs
+++ b/tests/SettingsManagerTests.cs
@@ -331,4 +331,63 @@ public class SettingsManagerTests : IDisposable
   {
     return new SettingsManager(_testSettingsFile, null, null);
   }
+
+  [Fact]
+  public void SaveSettings_SavesAudioDeviceId_WhenProvided()
+  {
+    // Arrange
+    var settingsManager = CreateSettingsManagerWithoutConfig();
+    var deviceId = "{0.0.0.00000000}.{12345678-1234-1234-1234-123456789abc}";
+
+    // Act
+    settingsManager.SaveSettings("https://test.local", "test_webhook", "media_player.test", deviceId);
+
+    // Assert
+    var json = File.ReadAllText(_testSettingsFile);
+    Assert.Contains("AudioDeviceId", json);
+    Assert.Contains(deviceId, json);
+  }
+
+  [Fact]
+  public void SaveSettings_SavesEmptyAudioDeviceId_WhenNotProvided()
+  {
+    // Arrange
+    var settingsManager = CreateSettingsManagerWithoutConfig();
+
+    // Act
+    settingsManager.SaveSettings("https://test.local", "test_webhook", "media_player.test");
+
+    // Assert
+    var json = File.ReadAllText(_testSettingsFile);
+    Assert.Contains("AudioDeviceId", json);
+    // Empty string value
+    Assert.Contains("\"AudioDeviceId\": \"\"", json);
+  }
+
+  [Fact]
+  public void SaveSettings_UpdatesAudioDeviceId_InExistingFile()
+  {
+    // Arrange
+    var initialJson = """
+      {
+        "HomeAssistant": {
+          "WebhookUrl": "https://old.local",
+          "WebhookId": "old_webhook",
+          "TargetMediaPlayer": "media_player.old",
+          "AudioDeviceId": ""
+        }
+      }
+      """;
+    File.WriteAllText(_testSettingsFile, initialJson);
+    var settingsManager = CreateSettingsManagerWithoutConfig();
+    var newDeviceId = "{0.0.0.00000000}.{abcdef12-3456-7890-abcd-ef1234567890}";
+
+    // Act
+    settingsManager.SaveSettings("https://new.local", "new_webhook", "media_player.new", newDeviceId);
+
+    // Assert
+    var json = File.ReadAllText(_testSettingsFile);
+    Assert.Contains(newDeviceId, json);
+    Assert.Contains("https://new.local", json);
+  }
 }

--- a/tests/TestConfigurationHelper.cs
+++ b/tests/TestConfigurationHelper.cs
@@ -23,7 +23,8 @@ public static class TestConfigurationHelper
         string webhookId = "test_webhook",
         string webhookPath = "/api/webhook/",
         string? targetMediaPlayer = null,
-        bool strictTls = true)
+        bool strictTls = true,
+        string audioDeviceId = "")
     {
         var configData = new Dictionary<string, string?>
         {
@@ -31,7 +32,8 @@ public static class TestConfigurationHelper
             { "HomeAssistant:WebhookPath", webhookPath },
             { "HomeAssistant:WebhookId", webhookId },
             { "HomeAssistant:TargetMediaPlayer", targetMediaPlayer ?? "media_player.test" },
-            { "HomeAssistant:StrictTLS", strictTls.ToString() }
+            { "HomeAssistant:StrictTLS", strictTls.ToString() },
+            { "HomeAssistant:AudioDeviceId", audioDeviceId }
         };
 
         return CreateConfiguration(configData);

--- a/tests/VolumeWatcherServiceTests.cs
+++ b/tests/VolumeWatcherServiceTests.cs
@@ -544,5 +544,173 @@ public class VolumeWatcherServiceTests
     }
 
     #endregion
+
+    #region ResolveMonitoredDevice tests — string stub, no COM/NAudio references
+
+    // ResolveMonitoredDevice<TDevice> is generic; we use string as the stub device type
+    // so these tests exercise pure logic only and introduce no additional Windows/COM/NAudio
+    // dependencies beyond the test project's net8.0-windows target.
+    // [WindowsFact] is NOT used here intentionally because no NAudio or COM types are referenced.
+
+    private static string? StubResolveDevice(
+        string? configuredDeviceId,
+        Func<string, string?> getDevice,
+        Func<string?> getDefaultDevice,
+        Action<System.Runtime.InteropServices.COMException, string> logWarning,
+        Action<string, string?> logInfo)
+        => VolumeWatcherService.ResolveMonitoredDevice(
+            configuredDeviceId,
+            getDevice,
+            getDefaultDevice,
+            d => d,   // name == the device string itself
+            logWarning,
+            logInfo);
+
+    [Fact]
+    public void ResolveMonitoredDevice_UsesGetDevice_WhenAudioDeviceIdIsConfigured()
+    {
+        var configuredId = "{0.0.0.00000000}.{test-device-id}";
+        var getDeviceCalled = false;
+        var getDefaultCalled = false;
+
+        StubResolveDevice(
+            configuredId,
+            id => { getDeviceCalled = true; return "speakers"; },
+            () => { getDefaultCalled = true; return "default-device"; },
+            (ex, id) => { },
+            (kind, name) => { });
+
+        Assert.True(getDeviceCalled, "GetDevice should be called when AudioDeviceId is configured");
+        Assert.False(getDefaultCalled, "GetDefaultAudioEndpoint should NOT be called when getDevice succeeds");
+    }
+
+    [Fact]
+    public void ResolveMonitoredDevice_UsesGetDefaultDevice_WhenAudioDeviceIdIsEmpty()
+    {
+        var getDeviceCalled = false;
+        var getDefaultCalled = false;
+
+        StubResolveDevice(
+            "",
+            id => { getDeviceCalled = true; return "speakers"; },
+            () => { getDefaultCalled = true; return "default-device"; },
+            (ex, id) => { },
+            (kind, name) => { });
+
+        Assert.False(getDeviceCalled, "GetDevice should NOT be called when AudioDeviceId is empty");
+        Assert.True(getDefaultCalled, "GetDefaultAudioEndpoint should be called when AudioDeviceId is empty");
+    }
+
+    [Fact]
+    public void ResolveMonitoredDevice_UsesGetDefaultDevice_WhenAudioDeviceIdIsNull()
+    {
+        var getDeviceCalled = false;
+        var getDefaultCalled = false;
+
+        StubResolveDevice(
+            null,
+            id => { getDeviceCalled = true; return "speakers"; },
+            () => { getDefaultCalled = true; return "default-device"; },
+            (ex, id) => { },
+            (kind, name) => { });
+
+        Assert.False(getDeviceCalled, "GetDevice should NOT be called when AudioDeviceId is null");
+        Assert.True(getDefaultCalled, "GetDefaultAudioEndpoint should be called when AudioDeviceId is null");
+    }
+
+    [Fact]
+    public void ResolveMonitoredDevice_FallsBackToDefault_WhenConfiguredDeviceNotFound()
+    {
+        var configuredId = "{0.0.0.00000000}.{missing-device-id}";
+        var comException = new System.Runtime.InteropServices.COMException("device not found", unchecked((int)0x80070490));
+        var warningLogged = false;
+        var getDefaultCalled = false;
+
+        StubResolveDevice(
+            configuredId,
+            id => throw comException,
+            () => { getDefaultCalled = true; return "default-device"; },
+            (ex, id) => { warningLogged = true; },
+            (kind, name) => { });
+
+        Assert.True(warningLogged, "A warning should be logged when the configured device is not found");
+        Assert.True(getDefaultCalled, "GetDefaultAudioEndpoint should be called as fallback");
+    }
+
+    [Fact]
+    public void ResolveMonitoredDevice_LogsConfiguredKind_WhenSpecificDeviceSelected()
+    {
+        var configuredId = "{0.0.0.00000000}.{test-device-id}";
+        var loggedKind = "";
+
+        StubResolveDevice(
+            configuredId,
+            id => "Headphones (USB Audio)",
+            () => "Speakers (Realtek)",
+            (ex, id) => { },
+            (kind, name) => { loggedKind = kind; });
+
+        Assert.Equal("configured", loggedKind);
+    }
+
+    [Fact]
+    public void ResolveMonitoredDevice_LogsDefaultKind_WhenNoDeviceConfigured()
+    {
+        var loggedKind = "";
+
+        StubResolveDevice(
+            "",
+            id => "Headphones (USB Audio)",
+            () => "Speakers (Realtek)",
+            (ex, id) => { },
+            (kind, name) => { loggedKind = kind; });
+
+        Assert.Equal("default", loggedKind);
+    }
+
+    [Fact]
+    public void ResolveMonitoredDevice_ReturnsConfiguredDevice_WhenFound()
+    {
+        var configuredId = "{0.0.0.00000000}.{test-device-id}";
+
+        var result = StubResolveDevice(
+            configuredId,
+            id => "Headphones (USB Audio)",
+            () => "Speakers (Realtek)",
+            (ex, id) => { },
+            (kind, name) => { });
+
+        Assert.Equal("Headphones (USB Audio)", result);
+    }
+
+    [Fact]
+    public void ResolveMonitoredDevice_ReturnsDefaultDevice_WhenNoDeviceConfigured()
+    {
+        var result = StubResolveDevice(
+            "",
+            id => "Headphones (USB Audio)",
+            () => "Speakers (Realtek)",
+            (ex, id) => { },
+            (kind, name) => { });
+
+        Assert.Equal("Speakers (Realtek)", result);
+    }
+
+    [Fact]
+    public void ResolveMonitoredDevice_ReturnsDefaultDevice_WhenConfiguredDeviceNotFound()
+    {
+        var comException = new System.Runtime.InteropServices.COMException("not found", unchecked((int)0x80070490));
+
+        var result = StubResolveDevice(
+            "{0.0.0.00000000}.{missing}",
+            id => throw comException,
+            () => "Speakers (Realtek)",
+            (ex, id) => { },
+            (kind, name) => { });
+
+        Assert.Equal("Speakers (Realtek)", result);
+    }
+
+    #endregion
 }
 


### PR DESCRIPTION
## v0.5.0

### What's new

**Audio device selector** (closes #32)
- New dropdown in Settings to choose a specific audio output device instead of always using the Windows default
- Device list populated from Core Audio API
- Selection persisted in `%APPDATA%` config as an endpoint ID
- Falls back to Windows default if the configured device is not found

### Internal improvements

- `ResolveMonitoredDevice` extracted as a generic `internal static` method with delegate injection for full unit testability
- `AudioDeviceId` JSON key is omitted (not written as `""`) when switching back to Windows default
- All Copilot review comments from PR #34 and PR #35 addressed
- CLAUDE.md updated with NAudio COM testability pattern and Copilot review rule