### PR TITLE
fix: upgrade release action to v2 to fix asset upload failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           Compress-Archive -Path publish/framework-dependent/* -DestinationPath HomeAssistantWindowsVolumeSync-${{ steps.get_version.outputs.VERSION }}-win-x64.zip
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: false
           prerelease: false


### PR DESCRIPTION
## Problem

`softprops/action-gh-release@v1` has a race condition: it creates and publishes the release immediately, then tries to upload assets in parallel. This causes 422 `Cannot upload assets to an immutable release` errors for all but the first uploaded file.

## Fix

Upgrade to `softprops/action-gh-release@v2` which handles atomic upload before publishing correctly.

## Affected releases

v0.4.3 and v0.5.0 both have empty release assets due to this bug.