### PR TITLE
fix: draft-then-publish release pattern and version alignment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,11 @@ jobs:
           # Framework-dependent zip
           Compress-Archive -Path publish/framework-dependent/* -DestinationPath HomeAssistantWindowsVolumeSync-${{ steps.get_version.outputs.VERSION }}-win-x64.zip
 
-      - name: Create Release
+      - name: Create Draft Release
+        id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          draft: false
+          draft: true
           prerelease: false
           generate_release_notes: true
           files: |
@@ -103,3 +104,14 @@ jobs:
             ## What's Changed
 
             See the full changelog below.
+
+      - name: Publish Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: ${{ steps.create_release.outputs.id }},
+              draft: false
+            });


### PR DESCRIPTION
## Summary

Two fixes to the release process:

### 1. Version alignment
Version is purely MinVer-driven from Git tags — no hardcoded `0.5.0` references found. Nothing to change here.

### 2. Draft-then-publish release pattern
Replaces the single `Create Release` step (which would fail on re-runs due to immutable release conflicts) with a two-step pattern:
1. Create the release as a **draft** and upload all artifacts
2. Flip `draft: false` via `actions/github-script` API call

This prevents the `tag_name was used by an immutable release` error when workflows are re-triggered on the same tag.

## Files Changed
- `.github/workflows/release.yml`