### PR TITLE
fix: exclude PDB files from release artifacts and installer (closes #39)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,11 @@ jobs:
       - name: Publish framework-dependent
         run: dotnet publish src/HomeAssistantWindowsVolumeSync.csproj -c Release -r win-x64 --self-contained false -o publish/framework-dependent
 
+      - name: Remove PDB files from publish output
+        shell: pwsh
+        run: |
+          Get-ChildItem -Path publish -Recurse -Filter "*.pdb" | Remove-Item -Force
+
       - name: Build Inno Setup installer
         shell: pwsh
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,10 @@ jobs:
       - name: Remove PDB files from publish output
         shell: pwsh
         run: |
-          Get-ChildItem -Path publish -Recurse -Filter "*.pdb" | Remove-Item -Force
+          $ErrorActionPreference = 'Stop'
+          Get-ChildItem -Path publish -Recurse -Filter "*.pdb" | Remove-Item -Force -ErrorAction Stop
+          $remaining = Get-ChildItem -Path publish -Recurse -Filter "*.pdb"
+          if ($remaining) { throw "PDB files still present after removal: $($remaining.FullName -join ', ')" }
 
       - name: Build Inno Setup installer
         shell: pwsh

--- a/installer/windows.iss
+++ b/installer/windows.iss
@@ -45,7 +45,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
 ; All published application files (self-contained build)
-Source: "..\publish\self-contained\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "..\publish\self-contained\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "*.pdb"
 
 [Icons]
 ; Start Menu shortcut

--- a/src/HomeAssistantWindowsVolumeSync.csproj
+++ b/src/HomeAssistantWindowsVolumeSync.csproj
@@ -30,6 +30,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <OutputType>WinExe</OutputType>
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Closes #39.

PDB debug symbol files were being included in release artifacts. Three layers of defence added:

### 1. `src/HomeAssistantWindowsVolumeSync.csproj`
Added `<DebugType>none</DebugType>` and `<DebugSymbols>false</DebugSymbols>` to the Release `PropertyGroup`. PDBs are never generated at publish time.

### 2. `installer/windows.iss`
Added `Excludes: "*.pdb"` to the `[Files]` entry. Belt-and-suspenders for the installer.

### 3. `.github/workflows/release.yml`
Added a "Remove PDB files from publish output" step before zip creation. Recursively deletes any `.pdb` files from both publish directories as a final safety net.